### PR TITLE
Update PhotoOrganization

### DIFF
--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -16,10 +16,10 @@ using MelonLoader;
 [assembly: AssemblyVersion(PhotoOrganization.BuildInfo.Version)]
 [assembly: AssemblyFileVersion(PhotoOrganization.BuildInfo.Version)]
 [assembly: NeutralResourcesLanguage("en")]
-[assembly: MelonModInfo(typeof(PhotoOrganization.PhotoOrganization), PhotoOrganization.BuildInfo.Name, PhotoOrganization.BuildInfo.Version, PhotoOrganization.BuildInfo.Author, PhotoOrganization.BuildInfo.DownloadLink)]
+[assembly: MelonInfo(typeof(PhotoOrganization.PhotoOrganization), PhotoOrganization.BuildInfo.Name, PhotoOrganization.BuildInfo.Version, PhotoOrganization.BuildInfo.Author, PhotoOrganization.BuildInfo.DownloadLink)]
 
 
 // Create and Setup a MelonModGame to mark a Mod as Universal or Compatible with specific Games.
 // If no MelonModGameAttribute is found or any of the Values for any MelonModGame on the Mod is null or empty it will be assumed the Mod is Universal.
 // Values for MelonModGame can be found in the Game's app.info file or printed at the top of every log directly beneath the Unity version.
-[assembly: MelonModGame(null, null)]
+[assembly: MelonGame("VRChat", "VRChat")]

--- a/PhotoOrganization.cs
+++ b/PhotoOrganization.cs
@@ -3,6 +3,8 @@ using System.IO;
 using System.Reflection;
 using MelonLoader;
 using Harmony;
+using System.Linq;
+using UnhollowerRuntimeLib.XrefScans;
 
 namespace PhotoOrganization
 {
@@ -39,9 +41,9 @@ namespace PhotoOrganization
                     }
                 }
             }
-
+            var TargetMethod = typeof(ObjectPublicCaUnique).GetMethods(BindingFlags.Static | BindingFlags.Public).Single(it => it.GetParameters().Length == 2 && XrefScanner.XrefScan(it).Any(jt => jt.Type == XrefType.Global && jt.ReadAsObject()?.ToString() == "{0}/VRChat/VRChat_{1}x{2}_{3}.png"));
             HarmonyInstance harmonyInstance = HarmonyInstance.Create("PhotoOrganization");
-            harmonyInstance.Patch(typeof(ObjectPublicCaUnique).GetMethod("Method_Private_Static_String_Int32_Int32_0", BindingFlags.Public | BindingFlags.Static), new HarmonyMethod(typeof(PhotoOrganization).GetMethod("CameraFolderOrganize", BindingFlags.Static | BindingFlags.NonPublic)));
+            harmonyInstance.Patch(TargetMethod, new HarmonyMethod(typeof(PhotoOrganization).GetMethod("CameraFolderOrganize", BindingFlags.Static | BindingFlags.NonPublic)));
         }
 
         private static bool CameraFolderOrganize(ref string __result) { __result = string.Format("{0}/{1}/{2}.png", new object[] { FolderPath, DateTime.Now.ToString("yyyy-MM-dd"), DateTime.Now.ToString("HH-mm-ss.fff") }); return false; }


### PR DESCRIPTION
Updated to work on MelonLoader 0.2.7+/VRChat build 984. Now using Xref to find the target method that needs to be patched.